### PR TITLE
Add input clock parametric frequency for SPI (closes #89)

### DIFF
--- a/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/tb_top_spi_controller.vhd
+++ b/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/tb_top_spi_controller.vhd
@@ -46,6 +46,8 @@ ARCHITECTURE behavior OF tb_top_spi_controller IS
          motor_pwm_left_i : IN  std_logic_vector(7 downto 0);
          motor_pwm_rght_i : IN  std_logic_vector(7 downto 0);
          motor_dps_limit_i : IN  std_logic_vector(15 downto 0);
+         motor_dps_left_i : IN  std_logic_vector(15 downto 0);
+         motor_dps_rght_i : IN  std_logic_vector(15 downto 0);
          led_eye_left_rgb_i : IN  std_logic_vector(23 downto 0);
          led_eye_rght_rgb_i : IN  std_logic_vector(23 downto 0);
          led_blink_left_rgb_i : IN  std_logic_vector(23 downto 0);
@@ -66,6 +68,8 @@ ARCHITECTURE behavior OF tb_top_spi_controller IS
    signal motor_pwm_left_i : std_logic_vector(7 downto 0) := (others => '0');
    signal motor_pwm_rght_i : std_logic_vector(7 downto 0) := (others => '0');
    signal motor_dps_limit_i : std_logic_vector(15 downto 0) := (others => '0');
+   signal motor_dps_left_i : std_logic_vector(15 downto 0) := (others => '0');
+   signal motor_dps_rght_i : std_logic_vector(15 downto 0) := (others => '0');
    signal led_eye_left_rgb_i : std_logic_vector(23 downto 0) := (others => '0');
    signal led_eye_rght_rgb_i : std_logic_vector(23 downto 0) := (others => '0');
    signal led_blink_left_rgb_i : std_logic_vector(23 downto 0) := (others => '0');
@@ -91,6 +95,8 @@ BEGIN
           motor_pwm_left_i => motor_pwm_left_i,
           motor_pwm_rght_i => motor_pwm_rght_i,
           motor_dps_limit_i => motor_dps_limit_i,
+          motor_dps_left_i => motor_dps_left_i,
+          motor_dps_rght_i => motor_dps_rght_i,
           led_eye_left_rgb_i => led_eye_left_rgb_i,
           led_eye_rght_rgb_i => led_eye_rght_rgb_i,
           led_blink_left_rgb_i => led_blink_left_rgb_i,

--- a/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/top_spi_controller.v
+++ b/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/top_spi_controller.v
@@ -1,5 +1,13 @@
 
 module top_spi_controller
+  #(
+    // it has to be an integer number, if not integer, round it to the closest
+    // if using the PLL, use the resulting pll clock
+    parameter G_CLK_FREQ_MHZ = 12  // Alhambra II 12MHz
+    //parameter G_CLK_FREQ_MHZ = 25  // ULX3S 25MHz
+    //parameter G_CLK_FREQ_MHZ = 100  // using PLL (use the generated frequency)
+  )
+
 (
   input  clk,
   input  rst,
@@ -52,7 +60,9 @@ module top_spi_controller
   assign rpi_running = ~rst;
   assign leds[7:1] = 0;
 
-  spi_ctrl i_spi_ctrl
+  spi_ctrl
+  #(.G_CLK_FREQ_MHZ(G_CLK_FREQ_MHZ)
+  ) i_spi_ctrl
   (
     .rst         (rst),
     .clk         (clk),

--- a/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/top_spi_controller_wrp.v
+++ b/Blocks/General_Blocks/spi/alhambra_ii/spi_controller/apio/top_spi_controller_wrp.v
@@ -2,6 +2,14 @@
 // These port are not used in normal operation
 
 module top_spi_controller_wrp
+  #(
+    // it has to be an integer number, if not integer, round it to the closest
+    // if using the PLL, use the resulting pll clock
+    parameter G_CLK_FREQ_MHZ = 12  // Alhambra II 12MHz
+    //parameter G_CLK_FREQ_MHZ = 25  // ULX3S 25MHz
+    //parameter G_CLK_FREQ_MHZ = 100  // using PLL (use the generated frequency
+  )
+
 (
   input  clk,
   input  rst,
@@ -49,7 +57,10 @@ module top_spi_controller_wrp
   //assign motor_dps_limit_c = 16'h03E8; // this is max recommended speed
  
 
-  top_spi_controller i_top_spi_ctrl
+  top_spi_controller
+  #(.G_CLK_FREQ_MHZ(G_CLK_FREQ_MHZ)
+  )
+  i_top_spi_controller
   (
     .rst         (rst),
     .clk         (clk),


### PR DESCRIPTION
Until now the SPI worked with a external clock frequency of 12MHz
Now there is a parameter G_CLK_FREQ_MHZ that can be modified in order
to use another input clock frequency.
Alhambra II is 12 MHz
ULX3S is 25MHz
But also a PLL can be used, and some projects the clock frequency is:

-  [50MHz](https://github.com/JdeRobot/FPGA-robotics/tree/e4b2cb3a0ca30fb74783fdb0ae5a1b956bb75a0d/Projects/ComputerVision/ulx3s/apio/ov7670_rgb_yuv_320x240_rg_50mhz)
- [100MHz](https://github.com/JdeRobot/FPGA-robotics/tree/e4b2cb3a0ca30fb74783fdb0ae5a1b956bb75a0d/Projects/ComputerVision/alhambra_ii/apio/ov7670_rgb_yuv_80x60)