### PR TITLE
remove Vdesign_top___024root.h in example5 (closes #158)

### DIFF
--- a/utils/poc_verilator_simulation/sim/example5/src/main.cpp
+++ b/utils/poc_verilator_simulation/sim/example5/src/main.cpp
@@ -18,7 +18,7 @@
 
 // verilator headers
 #include "Vdesign_top.h"
-#include "Vdesign_top___024root.h"
+//#include "Vdesign_top___024root.h"
 #include "verilated.h"
 #include "verilated_vcd_c.h"
 


### PR DESCRIPTION
in file  `/utils/poc_verilator_simulation/sim/example5/src/main.cpp`